### PR TITLE
improve registration service error handling

### DIFF
--- a/src/components/RegistrationProvider.tsx
+++ b/src/components/RegistrationProvider.tsx
@@ -26,12 +26,14 @@ const RegistrationProvider = ({ children }: { children?: React.ReactNode }) => {
   getSignupDataRef.current = async () => {
     try {
       const data = await getSignupData();
-      if (error || !isEqual(data, signupData)) {
+      if (!isEqual(data, signupData)) {
         setSignupData(data);
       }
+      setError(undefined);
       setStatusUnknown(false);
     } catch (e) {
-      setError(errorMessage(e) || 'An error occurred retrieving activation status.');
+      setError(`An error occurred retrieving registration status. ${errorMessage(e)}`);
+      setStatusUnknown(false);
     }
   };
 
@@ -44,7 +46,7 @@ const RegistrationProvider = ({ children }: { children?: React.ReactNode }) => {
     if (pollStatus) {
       const handle = setInterval(() => {
         getSignupDataRef.current?.();
-      }, 5000);
+      }, 10000);
       return () => {
         clearInterval(handle);
       };

--- a/src/components/__tests__/RegistrationProvider.spec.tsx
+++ b/src/components/__tests__/RegistrationProvider.spec.tsx
@@ -25,6 +25,11 @@ describe('RegistrationProvider', () => {
     expect(state).not.toBeNull();
     expect(api).not.toBeNull();
 
+    // run all use effects
+    await act(async () => {
+      // do nothing
+    });
+
     await act(async () => {
       api.setError('test');
     });

--- a/src/routes/SandboxPage/SandboxPage.tsx
+++ b/src/routes/SandboxPage/SandboxPage.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import { Bullseye, Flex, PageSection, Spinner, TextContent } from '@patternfly/react-core';
+import {
+  Alert,
+  AlertVariant,
+  Bullseye,
+  Flex,
+  PageSection,
+  Spinner,
+  TextContent,
+} from '@patternfly/react-core';
 import SandboxPageBanner from '../../components/PageBanner/SandboxPageBanner';
 import HowItWorksCard from '../../components/HowItWorksCard/HowItWorksCard';
 import GetStartedCard from '../../components/GetStartedCard/GetStartedCard';
@@ -7,7 +15,7 @@ import ServiceCatalog from '../../components/ServiceCatalog/ServiceCatalog';
 import { useRegistrationContext } from '../../hooks/useRegistrationContext';
 
 const SandboxPage = () => {
-  const [{ status }] = useRegistrationContext();
+  const [{ status, error }] = useRegistrationContext();
   const provisioning = status === 'provisioning';
   const showOverview = status !== 'ready' && !provisioning;
   return (
@@ -20,6 +28,16 @@ const SandboxPage = () => {
           </Bullseye>
         ) : (
           <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXl' }}>
+            {error ? (
+              <Alert
+                title="An error occurred"
+                variant={AlertVariant.danger}
+                className="pf-u-mb-lg"
+                style={{ boxShadow: 'var(--pf-global--BoxShadow--sm)' }}
+              >
+                {error}
+              </Alert>
+            ) : null}
             {showOverview ? (
               <>
                 <GetStartedCard />

--- a/src/services/axios-instance.ts
+++ b/src/services/axios-instance.ts
@@ -1,8 +1,3 @@
-import {
-  errorInterceptor,
-  interceptor401,
-  interceptor500,
-} from '@redhat-cloud-services/frontend-components-utilities/interceptors';
 import axios, { AxiosRequestConfig } from 'axios';
 
 const baseURL =
@@ -29,6 +24,3 @@ axiosInstance.interceptors.request.use((reqConfig: AxiosRequestConfig) => {
     };
   });
 });
-axiosInstance.interceptors.response.use(undefined, interceptor401);
-axiosInstance.interceptors.response.use(undefined, interceptor500);
-axiosInstance.interceptors.response.use(undefined, errorInterceptor);


### PR DESCRIPTION
Turns out that the stage sso doesn't work with registration service. In testing, I found that the addition of the axios interceptors are causing issues in reporting errors. As such errors weren't showing up correctly in the UI. Additionally, fetching the signup data fails, an error is now displayed.

![image](https://github.com/RedHatInsights/developer-sandbox-ui/assets/14068621/2b6b86c3-cf44-4d5b-9109-47a1eef6d08f)
