### PR TITLE
request sign up immediately without opening modal

### DIFF
--- a/src/components/RegistrationModal/__tests__/RegistrationModal.spec.tsx
+++ b/src/components/RegistrationModal/__tests__/RegistrationModal.spec.tsx
@@ -27,22 +27,8 @@ describe('RegistrationModal', () => {
     jest.useFakeTimers();
   });
 
-  it('should render the activate screen', () => {
-    render(<RegistrationModal onClose={() => null} initialStatus="new" />);
-    expect(screen.getByRole('button', { name: 'Activate' })).toBeDisabled();
-  });
-
-  it('should render the activate screen in ', () => {
-    render(<RegistrationModal onClose={() => null} initialStatus="new" />);
-    expect(screen.getByRole('button', { name: 'Activate' })).toBeDisabled();
-  });
-
   it('should render the activate button', () => {
     render(<RegistrationModal onClose={() => null} />);
-    expect(screen.getByRole('button', { name: 'Activate' })).toBeDisabled();
-
-    screen.getByRole('checkbox').click();
-
     expect(screen.getByRole('button', { name: 'Activate' })).not.toBeDisabled();
   });
 
@@ -59,7 +45,7 @@ describe('RegistrationModal', () => {
   it('should render the ready screen', () => {
     const onClose = jest.fn();
     render(<RegistrationModal onClose={onClose} initialStatus="ready" />);
-    const button = screen.getByRole('button', { name: 'Launch Sandbox' });
+    const button = screen.getByRole('button', { name: 'Got it' });
     expect(button).not.toBeDisabled();
     button.click();
     expect(onClose).toHaveBeenCalled();
@@ -78,7 +64,6 @@ describe('RegistrationModal', () => {
       },
     });
     render(<RegistrationModal onClose={() => null} />);
-    screen.getByRole('checkbox').click();
     screen.getByRole('button', { name: 'Activate' }).click();
     expect(signupMock).toHaveBeenCalled();
     await waitFor(() => {
@@ -89,9 +74,9 @@ describe('RegistrationModal', () => {
         ready: true,
       },
     });
-    jest.advanceTimersByTime(1000);
+    jest.advanceTimersByTime(2000);
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Launch Sandbox' })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Got it' })).not.toBeDisabled();
     });
   });
 
@@ -102,7 +87,6 @@ describe('RegistrationModal', () => {
       },
     });
     render(<RegistrationModal onClose={() => null} />);
-    screen.getByRole('checkbox').click();
     screen.getByRole('button', { name: 'Activate' }).click();
     expect(signupMock).toHaveBeenCalled();
     await waitFor(() => {
@@ -113,9 +97,9 @@ describe('RegistrationModal', () => {
         ready: true,
       },
     });
-    jest.advanceTimersByTime(1000);
+    jest.advanceTimersByTime(2000);
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Launch Sandbox' })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Got it' })).not.toBeDisabled();
     });
   });
 
@@ -127,7 +111,6 @@ describe('RegistrationModal', () => {
       },
     });
     render(<RegistrationModal onClose={() => null} />);
-    screen.getByRole('checkbox').click();
     screen.getByRole('button', { name: 'Activate' }).click();
     expect(signupMock).toHaveBeenCalled();
     await waitFor(() => {
@@ -179,7 +162,7 @@ describe('RegistrationModal', () => {
       },
     });
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Launch Sandbox' })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Got it' })).not.toBeDisabled();
     });
   });
 });

--- a/src/routes/SandboxPage/SandboxPage.tsx
+++ b/src/routes/SandboxPage/SandboxPage.tsx
@@ -18,8 +18,7 @@ import { useRegistrationContext } from '../../hooks/useRegistrationContext';
 
 const SandboxPage = () => {
   const [{ status, error }] = useRegistrationContext();
-  const provisioning = status === 'provisioning';
-  const showOverview = status !== 'ready' && !provisioning;
+  const showOverview = status !== 'ready';
   return (
     <>
       <SandboxPageBanner />
@@ -48,16 +47,13 @@ const SandboxPage = () => {
             ) : (
               <>
                 <TextContent>
-                  <Text component={TextVariants.h1}>
-                    {provisioning ? 'Available service after provisioning' : 'Available services'}
-                  </Text>
+                  <Text component={TextVariants.h1}>Available services</Text>
                   <Text component={TextVariants.p}>
-                    {provisioning
-                      ? 'Your Sandbox account is waiting for provisioning. Once complete, these are all the cool things that are available to you.'
-                      : 'Now that your Sandbox is activated, these are all the cool things that are available to you, right in your Sandbox!'}
+                    Now that your Sandbox is activated, these are all the cool things that are
+                    available to you, right in your Sandbox!
                   </Text>
                 </TextContent>
-                <ServiceCatalog isDisabled={provisioning} />
+                <ServiceCatalog />
               </>
             )}
           </Flex>

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -1,0 +1,2 @@
+export const SHORT_INTERVAL = 2000;
+export const LONG_INTERVAL = 20000;

--- a/src/utils/registration-context.ts
+++ b/src/utils/registration-context.ts
@@ -12,6 +12,7 @@ export type RegistrationState = {
 
 // actions
 export type RegistrationActions = {
+  refreshSignupData: () => Promise<void>;
   setShowUserSignup: (showUserSignup: boolean) => void;
   setSignupData: (data: SignupData | undefined) => void;
   setError: (error: string | undefined) => void;


### PR DESCRIPTION
When the user clicks the `Get started` button, instead of opening up the registration modal, we immediately send the signup request. The button will transition to `Preparing your Sandbox`.
![image](https://github.com/RedHatInsights/developer-sandbox-ui/assets/14068621/30aefdc5-5d11-4e82-a6d6-4dd157d89bea)

Once their account is provisioned, the modal will open:
![image](https://github.com/RedHatInsights/developer-sandbox-ui/assets/14068621/2b3840d9-d255-498e-be5a-cda569e8f3bd)
