### PR TITLE
create unique keys for service catalog items

### DIFF
--- a/src/components/ServiceCatalog/ServiceCatalog.tsx
+++ b/src/components/ServiceCatalog/ServiceCatalog.tsx
@@ -13,7 +13,7 @@ const ServiceCatalog = ({ isDisabled }: Props) => {
   return (
     <Gallery hasGutter minWidths={{ default: '330px' }}>
       {services.map((service) => (
-        <GalleryItem key={service.title}>
+        <GalleryItem key={service.id}>
           <ServiceCard {...service} launchUrl={isDisabled ? undefined : service.launchUrl} />
         </GalleryItem>
       ))}

--- a/src/hooks/useSandboxServices.ts
+++ b/src/hooks/useSandboxServices.ts
@@ -5,6 +5,7 @@ import devSpacesUrl from '../images/Product_Icon-Red_Hat-OpenShift_Dev_Spaces-RG
 import { useRegistrationContext } from './useRegistrationContext';
 
 export type Service = {
+  id: string;
   title: string;
   subtitle: string;
   description: string;
@@ -18,6 +19,7 @@ export const useSandboxServices = () => {
   return React.useMemo<Service[]>(
     () => [
       {
+        id: 'red-hat-openshift',
         title: 'Red Hat',
         subtitle: 'OpenShift',
         description:
@@ -30,6 +32,7 @@ export const useSandboxServices = () => {
             : signupData?.consoleURL,
       },
       {
+        id: 'red-hat-dev-spaces',
         title: 'Red Hat',
         subtitle: 'Dev Spaces',
         description:
@@ -39,6 +42,7 @@ export const useSandboxServices = () => {
         launchUrl: signupData?.cheDashboardURL,
       },
       {
+        id: 'red-hat-data-science',
         title: 'Red Hat',
         subtitle: 'Data Science',
         description:


### PR DESCRIPTION
Create unique keys for the service catalog items to remove a warning from react because catalog items currently share the same title which was used as a key.