### PR TITLE
show loading spinner when status is pending-aproval

### DIFF
--- a/src/components/GetStartedCard/GetStartedCard.tsx
+++ b/src/components/GetStartedCard/GetStartedCard.tsx
@@ -36,6 +36,8 @@ const GetStartedCard = () => {
   const [error, setError] = React.useState<string | undefined>();
   const [loading, setLoading] = React.useState(false);
   const [state, { setShowUserSignup, refreshSignupData }] = useRegistrationContext();
+  const isButtonDisabled =
+    loading || state.status === 'pending-approval' || state.status === 'provisioning';
   return (
     <>
       <Card>
@@ -88,10 +90,8 @@ const GetStartedCard = () => {
                 </Alert>
               ) : null}
               <AnalyticsButton
-                isDisabled={
-                  loading || state.status === 'pending-approval' || state.status === 'provisioning'
-                }
-                isLoading={loading || state.status === 'provisioning'}
+                isDisabled={isButtonDisabled}
+                isLoading={isButtonDisabled}
                 onClick={async () => {
                   if (state.status === 'new') {
                     try {


### PR DESCRIPTION
Updates the get started card to include a spinner while the button is disabled in the `pending-approval` state. We now treat `pending-approval` and `provisioning` in the same manner.