### PR TITLE
Clean up PF4 references

### DIFF
--- a/src/components/GetStartedCard/GetStartedCard.tsx
+++ b/src/components/GetStartedCard/GetStartedCard.tsx
@@ -21,7 +21,7 @@ import useRegistrationService from '../../hooks/useRegistrationService';
 const PrimaryCheckIcon = () => (
   <CheckIcon
     style={{
-      color: 'var(--pf-global--primary-color--100)',
+      color: 'var(--pf-v5-global--primary-color--100)',
     }}
   />
 );
@@ -47,17 +47,17 @@ const GetStartedCard = () => {
               md={4}
               order={{ md: '1' }}
               style={{ alignSelf: 'center' }}
-              className="pf-u-text-align-center"
+              className="pf-v5-u-text-align-center"
             >
               <img
                 src={heroImg}
                 style={{ maxHeight: 200 }}
-                className="pf-u-display-block pf-u-m-auto pf-u-mb-lg pf-u-mb-auto-on-md"
+                className="pf-v5-u-display-block pf-v5-u-m-auto pf-v5-u-mb-lg pf-v5-u-mb-auto-on-md"
               />
             </GridItem>
             <GridItem md={8}>
               <Title headingLevel="h1">Start exploring Developer Sandbox for free</Title>
-              <List isPlain className="pf-u-p-md pf-u-pt-lg pf-u-pb-lg">
+              <List isPlain className="pf-v5-u-p-md pf-v5-u-pt-lg pf-v5-u-pb-lg">
                 <ListItem icon={<PrimaryCheckIcon />}>
                   Instant access to a free pre-configured for learning and experimenting with
                   OpenShift, Kubernetes, and containers.
@@ -84,7 +84,7 @@ const GetStartedCard = () => {
                   variant={AlertVariant.danger}
                   actionClose={<AlertActionCloseButton onClose={() => setError(undefined)} />}
                   isInline
-                  className="pf-u-mb-lg"
+                  className="pf-v5-u-mb-lg"
                 >
                   {error}
                 </Alert>
@@ -108,7 +108,7 @@ const GetStartedCard = () => {
                     setShowUserSignup(true);
                   }
                 }}
-                className="pf-u-w-100 pf-u-w-initial-on-sm"
+                className="pf-v5-u-w-100 pf-v5-u-w-initial-on-sm"
                 analytics={{
                   event: 'DevSandbox Signup Start',
                 }}
@@ -121,7 +121,7 @@ const GetStartedCard = () => {
                 href="https://developers.redhat.com/developer-sandbox"
                 target="_blank"
                 rel="noopener"
-                className="pf-u-w-100 pf-u-w-initial-on-sm"
+                className="pf-v5-u-w-100 pf-v5-u-w-initial-on-sm"
                 style={{
                   display: 'inline-block',
                   whiteSpace: 'initial',

--- a/src/components/HowItWorksCard/HowItWorksCard.scss
+++ b/src/components/HowItWorksCard/HowItWorksCard.scss
@@ -2,7 +2,7 @@ $arrow-size: 5px;
 
 .how-it-works {
   text-align: center;
-  max-width: var(--pf-global--breakpoint--lg);
+  max-width: var(--pf-v5-global--breakpoint--lg);
   margin-left: auto;
   margin-right: auto;
 
@@ -26,7 +26,7 @@ $arrow-size: 5px;
 
       &:before {
         content: '';
-        border-top: 1px solid var(--pf-global--BorderColor--200);
+        border-top: 1px solid var(--pf-v5-global--BorderColor--200);
         width: 100%;
         height: 0;
         position: absolute;
@@ -40,7 +40,7 @@ $arrow-size: 5px;
         height: 0;
         border-top: $arrow-size solid transparent;
         border-bottom: $arrow-size solid transparent;
-        border-left: $arrow-size * 2 solid var(--pf-global--BorderColor--200);
+        border-left: $arrow-size * 2 solid var(--pf-v5-global--BorderColor--200);
         border-right: 0;
         position: absolute;
         right: -1px;
@@ -51,9 +51,9 @@ $arrow-size: 5px;
     > div:nth-child(odd) {
       flex-grow: 2;
       flex-basis: 150px;
-      border: 1px solid var(--pf-global--BorderColor--200);
+      border: 1px solid var(--pf-v5-global--BorderColor--200);
       border-radius: 24px;
-      background-color: var(--pf-global--BackgroundColor--100);
+      background-color: var(--pf-v5-global--BackgroundColor--100);
       white-space: nowrap;
     }
   }
@@ -74,7 +74,7 @@ $arrow-size: 5px;
         &:before {
           content: '';
           border-top: 0;
-          border-left: 1px solid var(--pf-global--BorderColor--200);
+          border-left: 1px solid var(--pf-v5-global--BorderColor--200);
           height: 100%;
           width: 0;
           position: absolute;
@@ -86,7 +86,7 @@ $arrow-size: 5px;
           content: '';
           width: 0;
           height: 0;
-          border-top: $arrow-size * 2 solid var(--pf-global--BorderColor--200);
+          border-top: $arrow-size * 2 solid var(--pf-v5-global--BorderColor--200);
           border-bottom: 0;
           border-left: $arrow-size solid transparent;
           border-right: $arrow-size solid transparent;

--- a/src/components/HowItWorksCard/HowItWorksCard.tsx
+++ b/src/components/HowItWorksCard/HowItWorksCard.tsx
@@ -22,7 +22,7 @@ const HowItWorksCard = () => (
           experience on OpenShift with the sandbox.
         </Text>
       </TextContent>
-      <img src={howItWorksImg} className="pf-u-w-75 pf-u-pt-md pf-u-pb-md" />
+      <img src={howItWorksImg} className="pf-v5-u-w-75 pf-v5-u-pt-md pf-v5-u-pb-md" />
       <div className="how-it-works__viz">
         <div>Import your code</div>
         <div />

--- a/src/components/PageBanner/PageBanner.tsx
+++ b/src/components/PageBanner/PageBanner.tsx
@@ -15,7 +15,7 @@ type Props = {
 };
 
 const PageBanner = ({ children, icon, title }: Props) => (
-  <PageSection variant={PageSectionVariants.light} className="pf-u-p-xl">
+  <PageSection variant={PageSectionVariants.light} className="pf-v5-u-p-xl">
     <Flex
       direction={{ default: 'column', sm: 'row' }}
       spaceItems={{ default: 'spaceItemsMd', sm: 'spaceItemsXl' }}

--- a/src/components/RegistrationModal/FooterButton.tsx
+++ b/src/components/RegistrationModal/FooterButton.tsx
@@ -7,8 +7,8 @@ const FooterButton = (
     'children' | 'onClick' | 'isDisabled' | 'isLoading'
   >,
 ) => (
-  <div className="pf-u-pt-xl pf-u-pt-md pf-u-text-align-center">
-    <Button {...props} className="pf-u-w-100 pf-u-w-initial-on-sm" />
+  <div className="pf-v5-u-pt-xl pf-v5-u-pt-md pf-v5-u-text-align-center">
+    <Button {...props} className="pf-v5-u-w-100 pf-v5-u-w-initial-on-sm" />
   </div>
 );
 

--- a/src/components/RegistrationModal/RegistrationModal.tsx
+++ b/src/components/RegistrationModal/RegistrationModal.tsx
@@ -116,7 +116,7 @@ const RegistrationModal = ({ onClose, initialStatus }: Props) => {
           variant={AlertVariant.danger}
           actionClose={<AlertActionCloseButton onClose={() => setError(undefined)} />}
           isInline
-          className="pf-u-mb-lg"
+          className="pf-v5-u-mb-lg"
         >
           {error}
         </Alert>
@@ -157,7 +157,7 @@ const RegistrationModal = ({ onClose, initialStatus }: Props) => {
                   </Text>
                 </TextContent>
                 <Form>
-                  <Grid hasGutter className="pf-u-mt-md" style={{ alignItems: 'end' }}>
+                  <Grid hasGutter className="pf-v5-u-mt-md" style={{ alignItems: 'end' }}>
                     <GridItem span={3}>
                       <FormGroup label="Country code" isRequired>
                         <TextInput
@@ -234,7 +234,11 @@ const RegistrationModal = ({ onClose, initialStatus }: Props) => {
                   </Text>
                 </TextContent>
                 <Form>
-                  <FormGroup label="Verification code" isRequired className="pf-u-mt-md pf-u-mb-md">
+                  <FormGroup
+                    label="Verification code"
+                    isRequired
+                    className="pf-v5-u-mt-md pf-v5-u-mb-md"
+                  >
                     <TextInput
                       aria-label="Veritification code"
                       isRequired
@@ -271,8 +275,8 @@ const RegistrationModal = ({ onClose, initialStatus }: Props) => {
                     </AnalyticsButton>
                     {codeResent ? (
                       <CheckIcon
-                        className="pf-u-ml-md"
-                        style={{ color: 'var(--pf-global--success-color--100)' }}
+                        className="pf-v5-u-ml-md"
+                        style={{ color: 'var(--pf-v5-global--success-color--100)' }}
                       />
                     ) : null}
                     <br />
@@ -321,7 +325,7 @@ const RegistrationModal = ({ onClose, initialStatus }: Props) => {
                     We are preparing your Sandbox. It will be available shortly.
                   </Text>
                 </TextContent>
-                <Bullseye className="pf-u-mt-2xl pf-u-mb-lg">
+                <Bullseye className="pf-v5-u-mt-2xl pf-v5-u-mb-lg">
                   <Spinner size="xl" />
                 </Bullseye>
                 <FooterButton isDisabled>Launch Sandbox</FooterButton>
@@ -334,7 +338,7 @@ const RegistrationModal = ({ onClose, initialStatus }: Props) => {
                 <TextContent>
                   <p>Your Sandbox account is waiting for approval.</p>
                 </TextContent>
-                <Bullseye className="pf-u-mt-2xl pf-u-mb-lg">
+                <Bullseye className="pf-v5-u-mt-2xl pf-v5-u-mb-lg">
                   <Spinner size="xl" />
                 </Bullseye>
                 <FooterButton onClick={() => onClose(signupData)}>Close</FooterButton>
@@ -349,7 +353,7 @@ const RegistrationModal = ({ onClose, initialStatus }: Props) => {
                     and start creating your applications!
                   </Text>
                 </TextContent>
-                <div className="pf-u-p-md">
+                <div className="pf-v5-u-p-md">
                   <img src={sandboxReadyImg} />
                 </div>
                 <FooterButton onClick={() => onClose(signupData)}>Got it</FooterButton>

--- a/src/components/ServiceCatalog/ServiceCard.tsx
+++ b/src/components/ServiceCatalog/ServiceCard.tsx
@@ -30,9 +30,9 @@ const ServiceCard = ({
   showDisabledButton,
   helperText,
 }: Props) => (
-  <Card className="pf-u-h-100">
+  <Card className="pf-v5-u-h-100">
     <CardHeader>
-      <img src={iconUrl} style={{ width: 48 }} className="pf-u-mr-md" />
+      <img src={iconUrl} style={{ width: 48 }} className="pf-v5-u-mr-md" />
       <TextContent>
         <Text component={TextVariants.h2}>{title}</Text>
         {subtitle}
@@ -46,7 +46,7 @@ const ServiceCard = ({
           component="a"
           isDisabled={showDisabledButton}
           href={launchUrl}
-          className="pf-u-mr-md"
+          className="pf-v5-u-mr-md"
           target="_blank"
           rel="noopener"
           analytics={{

--- a/src/root.scss
+++ b/src/root.scss
@@ -2,12 +2,12 @@
 
 :root {
   // Color Variables
-  --root-background-color: var(--pf-global--BackgroundColor--200);
-  --top-banner-background-color: var(--pf-global--Color--100);
-  --root-danger-color: var(--pf-global--danger-color--100);
+  --root-background-color: var(--pf-v5-global--BackgroundColor--200);
+  --top-banner-background-color: var(--pf-v5-global--Color--100);
+  --root-danger-color: var(--pf-v5-global--danger-color--100);
 
   // Spacer Variables
-  --root-xl-spacer: var(--pf-global--spacer--xl);
-  --root-md-spacer: var(--pf-global--spacer--md);
-  --root-sm-spacer: var(--pf-global--spacer--sm);
+  --root-xl-spacer: var(--pf-v5-global--spacer--xl);
+  --root-md-spacer: var(--pf-v5-global--spacer--md);
+  --root-sm-spacer: var(--pf-v5-global--spacer--sm);
 }

--- a/src/routes/SandboxPage/SandboxPage.tsx
+++ b/src/routes/SandboxPage/SandboxPage.tsx
@@ -20,7 +20,7 @@ const SandboxPage = () => {
   return (
     <>
       <SandboxPageBanner />
-      <PageSection className="pf-u-p-xl">
+      <PageSection className="pf-v5-u-p-xl">
         {status === 'unknown' ? (
           <Bullseye>
             <Spinner />
@@ -31,8 +31,8 @@ const SandboxPage = () => {
               <Alert
                 title="An error occurred"
                 variant={AlertVariant.danger}
-                className="pf-u-mb-lg"
-                style={{ boxShadow: 'var(--pf-global--BoxShadow--sm)' }}
+                className="pf-v5-u-mb-lg"
+                style={{ boxShadow: 'var(--pf-v5-global--BoxShadow--sm)' }}
               >
                 {error}
               </Alert>


### PR DESCRIPTION
PF4 is now disabled in stage/prod. We missed some styles in the UI still referencing PF4.

Before:
![image](https://github.com/user-attachments/assets/5eaf65a5-6d90-4acf-910b-79453d971a1e)

After (launch button missing due to entitlement issues):
![image](https://github.com/user-attachments/assets/578dc724-7ca6-4405-b45e-411cd81f1f9e)
