### PR TITLE
fix: Provision button not being displayed after enabling trial

### DIFF
--- a/src/components/ServiceCatalog/ServiceCatalog.tsx
+++ b/src/components/ServiceCatalog/ServiceCatalog.tsx
@@ -387,7 +387,7 @@ const ServiceCatalog = ({ isDisabled }: Props) => {
     } catch (e) {
       api.setError(errorMessage(e));
     }
-  }, []);
+  }, [auth, signupData]);
 
   React.useEffect(() => {
     const handle = setInterval(getAAPDataFn, SHORT_INTERVAL);


### PR DESCRIPTION
Fix a problem with the `user.entitlements.ansible.is_entitled` not being updated correctly after enabling the trial.

See: https://redhat-internal.slack.com/archives/C023VGW21NU/p1743006146957829