### PR TITLE
feat: add canary deployment logic

### DIFF
--- a/src/AppEntry.tsx
+++ b/src/AppEntry.tsx
@@ -1,3 +1,16 @@
+import { canaryDeploymentCheck } from './utils/canary-deployment';
+/*** CANARY Deployment for redirecting users to new UI
+ Users visiting the first time the UI will get assigned with a random number, the number will be stored in localstorage and reused everytime the user opens the UI.
+ The users that gets a number that is lower than a canary weight threshold, they will be redirected to the new ui,
+ the others will be using the current UI.
+ The threshold can be configured in the backend so that a bigger/smaller number of users can be routed to the new UI.
+ ***/
+// TODO get the threshold from the backend regsvc
+const UI_CANARY_WEIGHT_TRESHOLD = 95;
+canaryDeploymentCheck(UI_CANARY_WEIGHT_TRESHOLD);
+/** END canary UI deployment **/
+
+
 import React from 'react';
 import App from './App';
 

--- a/src/AppEntry.tsx
+++ b/src/AppEntry.tsx
@@ -1,16 +1,3 @@
-import { canaryDeploymentCheck } from './utils/canary-deployment';
-/*** CANARY Deployment for redirecting users to new UI
- Users visiting the first time the UI will get assigned with a random number, the number will be stored in localstorage and reused everytime the user opens the UI.
- The users that gets a number that is lower than a canary weight threshold, they will be redirected to the new ui,
- the others will be using the current UI.
- The threshold can be configured in the backend so that a bigger/smaller number of users can be routed to the new UI.
- ***/
-// TODO get the threshold from the backend regsvc
-const UI_CANARY_WEIGHT_TRESHOLD = 95;
-canaryDeploymentCheck(UI_CANARY_WEIGHT_TRESHOLD);
-/** END canary UI deployment **/
-
-
 import React from 'react';
 import App from './App';
 

--- a/src/components/AAPModal/AnsibleAutomationPlatformModal.tsx
+++ b/src/components/AAPModal/AnsibleAutomationPlatformModal.tsx
@@ -61,14 +61,14 @@ function AnsibleAutomationPlatformProvisioningModalContent(props: {
         </Text>
         <br />
         <Text component={TextVariants.p} data-testid="modal-content-docs">
-          While you wait, consider exploring the
+          New to Ansible Automation Platform? Get up to speed with our
           <a
-            className={'pf-v5-u-ml-xs'}
+            className={'pf-v5-u-ml-xs pf-v5-u-mr-xs'}
             target="_blank"
             rel="noreferrer"
-            href={'https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform'}
+            href={'http://red.ht/ansibledevsandboxpath'}
           >
-            AAP documentation
+            introductory learning path
           </a>
           <ExternalLinkAltIcon></ExternalLinkAltIcon>.
         </Text>

--- a/src/components/AAPModal/__tests__/AnsibleAutomationPlatformModal.spec.tsx
+++ b/src/components/AAPModal/__tests__/AnsibleAutomationPlatformModal.spec.tsx
@@ -96,9 +96,9 @@ describe('AnsibleAutomationPlatformModal', () => {
         `${provisioningLabel} can take up to 30 minutes. When ready, your instance will remain active for several hours.`,
       ),
     ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'AAP documentation' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'introductory learning path' })).toHaveAttribute(
       'href',
-      'https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform',
+      'http://red.ht/ansibledevsandboxpath',
     );
     // spinner should be there
     const progressBar = screen.getByRole('progressbar');

--- a/src/hooks/__tests__/useRegistrationService.spec.ts
+++ b/src/hooks/__tests__/useRegistrationService.spec.ts
@@ -4,6 +4,7 @@ import {
   getSignupData,
   initiatePhoneVerification,
   signup,
+  getUIConfigData,
 } from '../../services/registration-service';
 
 const axiosInstanceMock = {};
@@ -32,6 +33,12 @@ describe('useRegistrationService', () => {
     const { getSignupData: testFn } = useRegistrationService();
     testFn();
     expect(getSignupData).toHaveBeenCalledWith(axiosInstanceMock);
+  });
+
+  it('should delegate to getUIConfigData with axios instance', () => {
+    const { getUIConfigData: testFn } = useRegistrationService();
+    testFn();
+    expect(getUIConfigData).toHaveBeenCalledWith(axiosInstanceMock);
   });
 
   it('should delegate to initiatePhoneVerification with axios instance', () => {

--- a/src/hooks/__tests__/useRegistrationService.spec.ts
+++ b/src/hooks/__tests__/useRegistrationService.spec.ts
@@ -2,9 +2,9 @@ import useRegistrationService from '../useRegistrationService';
 import {
   completePhoneVerification,
   getSignupData,
+  getUIConfigData,
   initiatePhoneVerification,
   signup,
-  getUIConfigData,
 } from '../../services/registration-service';
 
 const axiosInstanceMock = {};

--- a/src/hooks/useRegistrationService.ts
+++ b/src/hooks/useRegistrationService.ts
@@ -1,6 +1,7 @@
 import {
   completePhoneVerification,
   getSignupData,
+  getUIConfigData,
   initiatePhoneVerification,
   signup,
 } from '../services/registration-service';
@@ -19,6 +20,8 @@ const useRegistrationService = () => {
 
     completePhoneVerification: async (code: string) =>
       completePhoneVerification(axiosInstance, code),
+
+    getUIConfigData: () => getUIConfigData(axiosInstance),
   };
 };
 

--- a/src/routes/SandboxPage/SandboxPage.tsx
+++ b/src/routes/SandboxPage/SandboxPage.tsx
@@ -1,64 +1,90 @@
 import React from 'react';
-import { Alert } from '@patternfly/react-core/dist/dynamic/components/Alert';
-import { AlertVariant } from '@patternfly/react-core/dist/dynamic/components/Alert';
+import { Alert, AlertVariant } from '@patternfly/react-core/dist/dynamic/components/Alert';
 import { Bullseye } from '@patternfly/react-core/dist/dynamic/layouts/Bullseye';
 import { Flex } from '@patternfly/react-core/dist/dynamic/layouts/Flex';
 import { PageSection } from '@patternfly/react-core/dist/dynamic/components/Page';
 import { Spinner } from '@patternfly/react-core/dist/dynamic/components/Spinner';
-import { Text } from '@patternfly/react-core/dist/dynamic/components/Text';
-import { TextContent } from '@patternfly/react-core/dist/dynamic/components/Text';
-import { TextVariants } from '@patternfly/react-core/dist/dynamic/components/Text';
+import { Text, TextContent, TextVariants } from '@patternfly/react-core/dist/dynamic/components/Text';
 import SandboxPageBanner from '../../components/PageBanner/SandboxPageBanner';
 import HowItWorksCard from '../../components/HowItWorksCard/HowItWorksCard';
 import GetStartedCard from '../../components/GetStartedCard/GetStartedCard';
 import ServiceCatalog from '../../components/ServiceCatalog/ServiceCatalog';
 import { useRegistrationContext } from '../../hooks/useRegistrationContext';
+import useRegistrationService from '../../hooks/useRegistrationService';
+import { canaryDeploymentCheck } from '../../utils/canary-deployment';
 
 const SandboxPage = () => {
   const [{ status, error }] = useRegistrationContext();
-  const showOverview = status !== 'ready';
-  return (
-    <>
-      <SandboxPageBanner />
-      <PageSection className="pf-v5-u-p-xl">
-        {status === 'unknown' ? (
-          <Bullseye>
-            <Spinner />
-          </Bullseye>
-        ) : (
-          <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXl' }}>
-            {error ? (
-              <Alert
-                title="An error occurred"
-                variant={AlertVariant.danger}
-                className="pf-v5-u-mb-lg"
-                style={{ boxShadow: 'var(--pf-v5-global--BoxShadow--sm)' }}
-              >
-                {error}
-              </Alert>
-            ) : null}
-            {showOverview ? (
-              <>
-                <GetStartedCard />
-                <HowItWorksCard />
-              </>
-            ) : (
-              <>
-                <TextContent>
-                  <Text component={TextVariants.h1}>Available services</Text>
-                  <Text component={TextVariants.p}>
-                    Now that your Sandbox is activated, these are all the cool things that are
-                    available to you, right in your Sandbox!
-                  </Text>
-                </TextContent>
-                <ServiceCatalog />
-              </>
-            )}
-          </Flex>
-        )}
-      </PageSection>
-    </>
-  );
+
+  /*** CANARY Deployment for redirecting users to new UI
+   Users visiting the first time the UI will get assigned with a random number, the number will be stored in localstorage and reused everytime the user opens the UI.
+   The users that gets a number that is lower than the canary weight threshold, they will be redirected to the new ui,
+   the others will be using the current UI.
+   The threshold can be configured in the backend so that a bigger/smaller number of users can be routed to the new UI.
+   ***/
+  const loadUIConfig = async function() {
+    console.log('loading ui config');
+    const { getUIConfigData } =
+      useRegistrationService();
+    const uiConfigData = await getUIConfigData();
+    if (uiConfigData == undefined) {
+      console.log('Unable to load uiconfig. Got undefined response.');
+    } else {
+      console.log('uiCanaryDeploymentWeight found: ', uiConfigData.uiCanaryDeploymentWeight);
+      canaryDeploymentCheck(uiConfigData.uiCanaryDeploymentWeight);
+    }
+  };
+  /** END canary UI deployment logic **/
+
+  try {
+    loadUIConfig();
+  } catch (e) {
+    console.log('Unable to retrieve uiConfigData. Got error:', e);
+  } finally {
+    const showOverview = status !== 'ready';
+    return (
+      <>
+        <SandboxPageBanner />
+        <PageSection className='pf-v5-u-p-xl'>
+          {status === 'unknown' ? (
+            <Bullseye>
+              <Spinner />
+            </Bullseye>
+          ) : (
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXl' }}>
+              {error ? (
+                <Alert
+                  title='An error occurred'
+                  variant={AlertVariant.danger}
+                  className='pf-v5-u-mb-lg'
+                  style={{ boxShadow: 'var(--pf-v5-global--BoxShadow--sm)' }}
+                >
+                  {error}
+                </Alert>
+              ) : null}
+              {showOverview ? (
+                <>
+                  <GetStartedCard />
+                  <HowItWorksCard />
+                </>
+              ) : (
+                <>
+                  <TextContent>
+                    <Text component={TextVariants.h1}>Available services</Text>
+                    <Text component={TextVariants.p}>
+                      Now that your Sandbox is activated, these are all the cool things that are
+                      available to you, right in your Sandbox!
+                    </Text>
+                  </TextContent>
+                  <ServiceCatalog />
+                </>
+              )}
+            </Flex>
+          )}
+        </PageSection>
+      </>
+    );
+  }
 };
 
 export default SandboxPage;

--- a/src/routes/SandboxPage/SandboxPage.tsx
+++ b/src/routes/SandboxPage/SandboxPage.tsx
@@ -4,7 +4,11 @@ import { Bullseye } from '@patternfly/react-core/dist/dynamic/layouts/Bullseye';
 import { Flex } from '@patternfly/react-core/dist/dynamic/layouts/Flex';
 import { PageSection } from '@patternfly/react-core/dist/dynamic/components/Page';
 import { Spinner } from '@patternfly/react-core/dist/dynamic/components/Spinner';
-import { Text, TextContent, TextVariants } from '@patternfly/react-core/dist/dynamic/components/Text';
+import {
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core/dist/dynamic/components/Text';
 import SandboxPageBanner from '../../components/PageBanner/SandboxPageBanner';
 import HowItWorksCard from '../../components/HowItWorksCard/HowItWorksCard';
 import GetStartedCard from '../../components/GetStartedCard/GetStartedCard';
@@ -22,10 +26,9 @@ const SandboxPage = () => {
    the others will be using the current UI.
    The threshold can be configured in the backend so that a bigger/smaller number of users can be routed to the new UI.
    ***/
-  const loadUIConfig = async function() {
+  const loadUIConfig = async function () {
     console.log('loading ui config');
-    const { getUIConfigData } =
-      useRegistrationService();
+    const { getUIConfigData } = useRegistrationService();
     const uiConfigData = await getUIConfigData();
     if (uiConfigData == undefined) {
       console.log('Unable to load uiconfig. Got undefined response.');
@@ -36,55 +39,57 @@ const SandboxPage = () => {
   };
   /** END canary UI deployment logic **/
 
-  try {
-    loadUIConfig();
-  } catch (e) {
-    console.log('Unable to retrieve uiConfigData. Got error:', e);
-  } finally {
-    const showOverview = status !== 'ready';
-    return (
-      <>
-        <SandboxPageBanner />
-        <PageSection className='pf-v5-u-p-xl'>
-          {status === 'unknown' ? (
-            <Bullseye>
-              <Spinner />
-            </Bullseye>
-          ) : (
-            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXl' }}>
-              {error ? (
-                <Alert
-                  title='An error occurred'
-                  variant={AlertVariant.danger}
-                  className='pf-v5-u-mb-lg'
-                  style={{ boxShadow: 'var(--pf-v5-global--BoxShadow--sm)' }}
-                >
-                  {error}
-                </Alert>
-              ) : null}
-              {showOverview ? (
-                <>
-                  <GetStartedCard />
-                  <HowItWorksCard />
-                </>
-              ) : (
-                <>
-                  <TextContent>
-                    <Text component={TextVariants.h1}>Available services</Text>
-                    <Text component={TextVariants.p}>
-                      Now that your Sandbox is activated, these are all the cool things that are
-                      available to you, right in your Sandbox!
-                    </Text>
-                  </TextContent>
-                  <ServiceCatalog />
-                </>
-              )}
-            </Flex>
-          )}
-        </PageSection>
-      </>
-    );
-  }
+  (async () => {
+    try {
+      await loadUIConfig();
+    } catch (e) {
+      console.log('Unable to retrieve uiConfigData. Got error:', e);
+    }
+  })();
+
+  const showOverview = status !== 'ready';
+  return (
+    <>
+      <SandboxPageBanner />
+      <PageSection className="pf-v5-u-p-xl">
+        {status === 'unknown' ? (
+          <Bullseye>
+            <Spinner />
+          </Bullseye>
+        ) : (
+          <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXl' }}>
+            {error ? (
+              <Alert
+                title="An error occurred"
+                variant={AlertVariant.danger}
+                className="pf-v5-u-mb-lg"
+                style={{ boxShadow: 'var(--pf-v5-global--BoxShadow--sm)' }}
+              >
+                {error}
+              </Alert>
+            ) : null}
+            {showOverview ? (
+              <>
+                <GetStartedCard />
+                <HowItWorksCard />
+              </>
+            ) : (
+              <>
+                <TextContent>
+                  <Text component={TextVariants.h1}>Available services</Text>
+                  <Text component={TextVariants.p}>
+                    Now that your Sandbox is activated, these are all the cool things that are
+                    available to you, right in your Sandbox!
+                  </Text>
+                </TextContent>
+                <ServiceCatalog />
+              </>
+            )}
+          </Flex>
+        )}
+      </PageSection>
+    </>
+  );
 };
 
 export default SandboxPage;

--- a/src/routes/SandboxPage/SandboxPage.tsx
+++ b/src/routes/SandboxPage/SandboxPage.tsx
@@ -14,38 +14,9 @@ import HowItWorksCard from '../../components/HowItWorksCard/HowItWorksCard';
 import GetStartedCard from '../../components/GetStartedCard/GetStartedCard';
 import ServiceCatalog from '../../components/ServiceCatalog/ServiceCatalog';
 import { useRegistrationContext } from '../../hooks/useRegistrationContext';
-import useRegistrationService from '../../hooks/useRegistrationService';
-import { canaryDeploymentCheck } from '../../utils/canary-deployment';
 
 const SandboxPage = () => {
   const [{ status, error }] = useRegistrationContext();
-
-  /*** CANARY Deployment for redirecting users to new UI
-   Users visiting the first time the UI will get assigned with a random number, the number will be stored in localstorage and reused everytime the user opens the UI.
-   The users that gets a number that is lower than the canary weight threshold, they will be redirected to the new ui,
-   the others will be using the current UI.
-   The threshold can be configured in the backend so that a bigger/smaller number of users can be routed to the new UI.
-   ***/
-  const loadUIConfig = async function () {
-    console.log('loading ui config');
-    const { getUIConfigData } = useRegistrationService();
-    const uiConfigData = await getUIConfigData();
-    if (uiConfigData == undefined) {
-      console.log('Unable to load uiconfig. Got undefined response.');
-    } else {
-      console.log('uiCanaryDeploymentWeight found: ', uiConfigData.uiCanaryDeploymentWeight);
-      canaryDeploymentCheck(uiConfigData.uiCanaryDeploymentWeight);
-    }
-  };
-  /** END canary UI deployment logic **/
-
-  (async () => {
-    try {
-      await loadUIConfig();
-    } catch (e) {
-      console.log('Unable to retrieve uiConfigData. Got error:', e);
-    }
-  })();
 
   const showOverview = status !== 'ready';
   return (

--- a/src/services/registration-service.ts
+++ b/src/services/registration-service.ts
@@ -1,12 +1,15 @@
 import axios, { AxiosInstance } from 'axios';
 import { recaptchaApiKey } from '../utils/recaptcha';
-import { SignupData } from '../types';
+import { SignupData, UiConfigData } from '../types';
 
 // signup endpoint
 const signupURL = '/api/v1/signup';
 
 // phone verification endpoint
 const phoneVerificationURL = '/api/v1/signup/verification';
+
+// uiconfig endpoint
+const uiconfigURL = '/api/v1/uiconfig';
 
 export const getSignupData = async (
   axiosInstance: AxiosInstance,
@@ -86,3 +89,19 @@ export const completePhoneVerification = async (axiosInstance: AxiosInstance, co
 export const isValidCountryCode = (countryCode: string) => /^[+]?[0-9]+$/.test(countryCode);
 export const isValidPhoneNumber = (phoneNumber: string) =>
   /^[(]?[0-9]+[)]?[-\s.]?[0-9]+[-\s./0-9]*$/im.test(phoneNumber);
+
+export const getUIConfigData = async (
+  axiosInstance: AxiosInstance,
+): Promise<UiConfigData | undefined> => {
+  try {
+    const { data } = await axiosInstance.get<UiConfigData>(uiconfigURL);
+    return data;
+  } catch (e) {
+    if (axios.isAxiosError(e)) {
+      if (e.response?.status === 404) {
+        return undefined;
+      }
+    }
+    throw e;
+  }
+};

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -11,3 +11,7 @@ export type SignupData = {
   defaultUserNamespace: string;
   proxyURL: string;
 };
+
+export type UiConfigData = {
+  uiCanaryDeploymentWeight: number;
+};

--- a/src/utils/__tests__/canary-deployment.spec.ts
+++ b/src/utils/__tests__/canary-deployment.spec.ts
@@ -1,0 +1,35 @@
+import { randomIntFromInterval, redirectUser } from '../canary-deployment';
+import useKubeApi from '../../hooks/useKubeApi';
+import useRegistrationService from '../../hooks/useRegistrationService';
+
+describe('canary-deployment', () => {
+
+  describe('randomIntFromInterval', () => {
+    it('should return a random number in between the provided range', () => {
+      const rndInt = randomIntFromInterval(1, 50);
+      expect(rndInt).toBeLessThanOrEqual(50);
+    });
+  });
+
+  describe('redirectUser', () => {
+
+    beforeEach(() => {
+      Object.defineProperty(window, "location", {
+        value: {
+          href: 'http://dummy.com'
+        },
+        writable: true
+      });
+    });
+
+    it('user should get redirected if weight is within the threshold', () => {
+      redirectUser(10, 50)
+      expect(window.location.href).toBe("https://sandbox.redhat.com");
+    });
+    it('user should not get redirected if weight is not within the threshold', () => {
+      redirectUser(30, 20)
+      expect(window.location.href).toBe("http://dummy.com");
+    });
+  });
+
+});

--- a/src/utils/__tests__/canary-deployment.spec.ts
+++ b/src/utils/__tests__/canary-deployment.spec.ts
@@ -1,6 +1,4 @@
 import { randomIntFromInterval, redirectUser } from '../canary-deployment';
-import useKubeApi from '../../hooks/useKubeApi';
-import useRegistrationService from '../../hooks/useRegistrationService';
 
 describe('canary-deployment', () => {
 

--- a/src/utils/__tests__/canary-deployment.spec.ts
+++ b/src/utils/__tests__/canary-deployment.spec.ts
@@ -1,7 +1,6 @@
 import { randomIntFromInterval, redirectUser } from '../canary-deployment';
 
 describe('canary-deployment', () => {
-
   describe('randomIntFromInterval', () => {
     it('should return a random number in between the provided range', () => {
       const rndInt = randomIntFromInterval(1, 50);
@@ -10,24 +9,22 @@ describe('canary-deployment', () => {
   });
 
   describe('redirectUser', () => {
-
     beforeEach(() => {
-      Object.defineProperty(window, "location", {
+      Object.defineProperty(window, 'location', {
         value: {
-          href: 'http://dummy.com'
+          href: 'http://dummy.com',
         },
-        writable: true
+        writable: true,
       });
     });
 
     it('user should get redirected if weight is within the threshold', () => {
-      redirectUser(10, 50)
-      expect(window.location.href).toBe("https://sandbox.redhat.com");
+      redirectUser(10, 50);
+      expect(window.location.href).toBe('https://sandbox.redhat.com');
     });
     it('user should not get redirected if weight is not within the threshold', () => {
-      redirectUser(30, 20)
-      expect(window.location.href).toBe("http://dummy.com");
+      redirectUser(30, 20);
+      expect(window.location.href).toBe('http://dummy.com');
     });
   });
-
 });

--- a/src/utils/canary-deployment.ts
+++ b/src/utils/canary-deployment.ts
@@ -1,3 +1,5 @@
+let RHDH_SANDBOX_UI_FQDN = 'https://sandbox.redhat.com';
+
 export const randomIntFromInterval = (min: number, max: number): number => { // min and max included
   return Math.floor(Math.random() * (max - min + 1) + min);
 };
@@ -5,7 +7,7 @@ export const randomIntFromInterval = (min: number, max: number): number => { // 
 export const redirectUser = (userWeightValue: number, weightThreshold: number) => {
   if (userWeightValue <= weightThreshold) {
     console.log('user will be redirected to new UI');
-    window.location.href = 'https://sandbox.redhat.com';
+    window.location.href = RHDH_SANDBOX_UI_FQDN;
     return
   }
   console.log('user will NOT be redirected to new UI.');

--- a/src/utils/canary-deployment.ts
+++ b/src/utils/canary-deployment.ts
@@ -1,6 +1,7 @@
-let RHDH_SANDBOX_UI_FQDN = 'https://sandbox.redhat.com';
+const RHDH_SANDBOX_UI_FQDN = 'https://sandbox.redhat.com';
 
-export const randomIntFromInterval = (min: number, max: number): number => { // min and max included
+export const randomIntFromInterval = (min: number, max: number): number => {
+  // min and max included
   return Math.floor(Math.random() * (max - min + 1) + min);
 };
 
@@ -8,13 +9,13 @@ export const redirectUser = (userWeightValue: number, weightThreshold: number) =
   if (userWeightValue <= weightThreshold) {
     console.log('user will be redirected to new UI');
     window.location.href = RHDH_SANDBOX_UI_FQDN;
-    return
+    return;
   }
   console.log('user will NOT be redirected to new UI.');
 };
 
 export const canaryDeploymentCheck = (canaryWeightThreshold: number) => {
-// check if user already has the UI canary deployment weight
+  // check if user already has the UI canary deployment weight
   const UICanaryWeightJson = localStorage.getItem('dev-sandbox.ui-canary-weight');
   if (UICanaryWeightJson == null) {
     // generate a new rand number for the user

--- a/src/utils/canary-deployment.ts
+++ b/src/utils/canary-deployment.ts
@@ -1,0 +1,31 @@
+export const randomIntFromInterval = (min: number, max: number): number => { // min and max included
+  return Math.floor(Math.random() * (max - min + 1) + min);
+};
+
+export const redirectUser = (userWeightValue: number, weightThreshold: number) => {
+  if (userWeightValue <= weightThreshold) {
+    console.log('user will be redirected to new UI');
+    window.location.href = 'https://sandbox.redhat.com';
+    return
+  }
+  console.log('user will NOT be redirected to new UI.');
+};
+
+export const canaryDeploymentCheck = (canaryWeightThreshold: number) => {
+// check if user already has the UI canary deployment weight
+  const UICanaryWeightJson = localStorage.getItem('dev-sandbox.ui-canary-weight');
+  if (UICanaryWeightJson == null) {
+    // generate a new rand number for the user
+    const rndInt = randomIntFromInterval(1, 100);
+    // store the new rand number for the user in the local storage as a string
+    localStorage.setItem('dev-sandbox.ui-canary-weight', JSON.stringify(rndInt)); // numbers must be saved as strings in localstorage
+    console.log('dev-sandbox.ui-canary-weight', rndInt);
+    // check if user should go to new UI and redirect in case
+    redirectUser(rndInt, canaryWeightThreshold);
+  } else {
+    // convert the string back to int
+    const UICanaryWeight = JSON.parse(UICanaryWeightJson);
+    console.log('dev-sandbox.ui-canary-weight', UICanaryWeight);
+    redirectUser(UICanaryWeight, canaryWeightThreshold);
+  }
+};

--- a/src/utils/canary-deployment.ts
+++ b/src/utils/canary-deployment.ts
@@ -7,11 +7,9 @@ export const randomIntFromInterval = (min: number, max: number): number => {
 
 export const redirectUser = (userWeightValue: number, weightThreshold: number) => {
   if (userWeightValue <= weightThreshold) {
-    console.log('user will be redirected to new UI');
     window.location.href = RHDH_SANDBOX_UI_FQDN;
     return;
   }
-  console.log('user will NOT be redirected to new UI.');
 };
 
 export const canaryDeploymentCheck = (canaryWeightThreshold: number) => {
@@ -22,13 +20,11 @@ export const canaryDeploymentCheck = (canaryWeightThreshold: number) => {
     const rndInt = randomIntFromInterval(1, 100);
     // store the new rand number for the user in the local storage as a string
     localStorage.setItem('dev-sandbox.ui-canary-weight', JSON.stringify(rndInt)); // numbers must be saved as strings in localstorage
-    console.log('dev-sandbox.ui-canary-weight', rndInt);
     // check if user should go to new UI and redirect in case
     redirectUser(rndInt, canaryWeightThreshold);
   } else {
     // convert the string back to int
     const UICanaryWeight = JSON.parse(UICanaryWeightJson);
-    console.log('dev-sandbox.ui-canary-weight', UICanaryWeight);
     redirectUser(UICanaryWeight, canaryWeightThreshold);
   }
 };


### PR DESCRIPTION
This PR adds custom canary deployment logic which will redirect some users to our new UI at `sandbox.redhat.com`.

After merging this change, users visiting the first time the UI will get assigned with a random number from 0 to 100, the number will be stored in localstorage as `dev-sandbox.ui-canary-weight` and reused every time the user comes back to the UI (unless they do it with a different browser or they delete the localstorage value).

On the registration service backend we now have a new api `GET /api/v1/uiconfig` which returns a json 
`{ "uiCanaryDeploymentWeight": number}`. 

The `uiCanaryDeploymentWeight` indicates the threshold weight ,  thus users getting a number lower than that will be redirected to the new ui at `sandbox.redhat.com`, the others will stay in the current HCC UI.

This way the threshold can be configured in the backend, so that a bigger/smaller number of users can be routed to the new UI, which allows us to "force" users to go to the new UI and perform the rollout incrementally.  